### PR TITLE
Issue #38: Upgrade dependencies (4.8.0)

### DIFF
--- a/components-core-typesystem/src/main/java/de/averbis/extraction/types/CoreTypeSystemDescriptionProvider.java
+++ b/components-core-typesystem/src/main/java/de/averbis/extraction/types/CoreTypeSystemDescriptionProvider.java
@@ -15,56 +15,20 @@
  */
 package de.averbis.extraction.types;
 
-import static org.apache.uima.util.TypeSystemUtil.loadTypeSystemDescriptionsFromClasspath;
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.uima.spi.TypeSystemProvider;
+import org.apache.uima.spi.TypeSystemProvider_ImplBase;
 
-import org.apache.uima.jcas.cas.TOP;
-import org.apache.uima.resource.metadata.TypeDescription;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.apache.uima.spi.JCasClassProvider;
-import org.apache.uima.spi.TypeSystemDescriptionProvider;
+import aQute.bnd.annotation.spi.ServiceProvider;
 
-public class CoreTypeSystemDescriptionProvider
-		implements TypeSystemDescriptionProvider, JCasClassProvider {
+@ServiceProvider(value = TypeSystemProvider.class, resolution = OPTIONAL)
+public class CoreTypeSystemDescriptionProvider extends TypeSystemProvider_ImplBase {
 
-	private List<TypeSystemDescription> typeSystemDescriptions;
-	private List<Class<? extends TOP>> jCasClasses;
+	public CoreTypeSystemDescriptionProvider() {
 
-
-	@Override
-	public synchronized List<TypeSystemDescription> listTypeSystemDescriptions() {
-
-		if (typeSystemDescriptions == null) {
-			typeSystemDescriptions = loadTypeSystemDescriptionsFromClasspath(getClass(), //
-					"AverbisInternalTypeSystem.xml", //
-					"AverbisTypeSystem.xml");
-		}
-		return typeSystemDescriptions;
-	}
-
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public synchronized List<Class<? extends TOP>> listJCasClasses() {
-
-		if (jCasClasses == null) {
-			List<Class<? extends TOP>> classes = new ArrayList<>();
-			ClassLoader cl = getClass().getClassLoader();
-
-			for (TypeSystemDescription tsd : listTypeSystemDescriptions()) {
-				for (TypeDescription td : tsd.getTypes()) {
-					try {
-						classes.add((Class<? extends TOP>) cl.loadClass(td.getName()));
-					} catch (ClassNotFoundException e) {
-						// This is acceptable - there may not be a JCas class
-					}
-				}
-			}
-			jCasClasses = classes;
-		}
-
-		return jCasClasses;
+		setTypeSystemLocations( //
+				"AverbisInternalTypeSystem.xml", //
+				"AverbisTypeSystem.xml");
 	}
 }

--- a/components-core-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
+++ b/components-core-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
@@ -1,0 +1,1 @@
+de.averbis.extraction.types.CoreTypeSystemDescriptionProvider

--- a/evaluation-typesystem/src/main/java/de/averbis/textanalysis/types/evaluation/EvaluationTypeSystemDescriptionProvider.java
+++ b/evaluation-typesystem/src/main/java/de/averbis/textanalysis/types/evaluation/EvaluationTypeSystemDescriptionProvider.java
@@ -15,55 +15,19 @@
  */
 package de.averbis.textanalysis.types.evaluation;
 
-import static org.apache.uima.util.TypeSystemUtil.loadTypeSystemDescriptionsFromClasspath;
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.uima.spi.TypeSystemProvider;
+import org.apache.uima.spi.TypeSystemProvider_ImplBase;
 
-import org.apache.uima.jcas.cas.TOP;
-import org.apache.uima.resource.metadata.TypeDescription;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.apache.uima.spi.JCasClassProvider;
-import org.apache.uima.spi.TypeSystemDescriptionProvider;
+import aQute.bnd.annotation.spi.ServiceProvider;
 
+@ServiceProvider(value = TypeSystemProvider.class, resolution = OPTIONAL)
 public class EvaluationTypeSystemDescriptionProvider
-		implements TypeSystemDescriptionProvider, JCasClassProvider {
+		extends TypeSystemProvider_ImplBase {
 
-	private static List<TypeSystemDescription> typeSystemDescriptions;
-	private static List<Class<? extends TOP>> jCasClasses;
+	public EvaluationTypeSystemDescriptionProvider() {
 
-
-	@Override
-	public synchronized List<TypeSystemDescription> listTypeSystemDescriptions() {
-
-		if (typeSystemDescriptions == null) {
-			typeSystemDescriptions = loadTypeSystemDescriptionsFromClasspath(getClass(), //
-					"EvaluationTypeSystem.xml");
-		}
-		return typeSystemDescriptions;
-	}
-
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public synchronized List<Class<? extends TOP>> listJCasClasses() {
-
-		if (jCasClasses == null) {
-			List<Class<? extends TOP>> classes = new ArrayList<>();
-			ClassLoader cl = getClass().getClassLoader();
-
-			for (TypeSystemDescription tsd : listTypeSystemDescriptions()) {
-				for (TypeDescription td : tsd.getTypes()) {
-					try {
-						classes.add((Class<? extends TOP>) cl.loadClass(td.getName()));
-					} catch (ClassNotFoundException e) {
-						// This is acceptable - there may not be a JCas class
-					}
-				}
-			}
-			jCasClasses = classes;
-		}
-
-		return jCasClasses;
+		setTypeSystemLocations("EvaluationTypeSystem.xml");
 	}
 }

--- a/evaluation-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
+++ b/evaluation-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
@@ -1,0 +1,1 @@
+de.averbis.textanalysis.types.evaluation.EvaluationTypeSystemDescriptionProvider

--- a/evaluation-typesystem/src/test/java/de/averbis/textanalysis/types/evaluation/ResolveTypeSystemTest.java
+++ b/evaluation-typesystem/src/test/java/de/averbis/textanalysis/types/evaluation/ResolveTypeSystemTest.java
@@ -17,15 +17,29 @@ package de.averbis.textanalysis.types.evaluation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.stream.Stream;
+
+import org.apache.uima.UIMAFramework;
 import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.resource.metadata.TypeDescription;
+import org.apache.uima.util.XMLInputSource;
 import org.junit.jupiter.api.Test;
 
 class ResolveTypeSystemTest {
 
 	@Test
 	void thatTypeSystemCanBeAutoDetectedAndResolved() throws Exception {
-		TypeSystemDescription tsd = TypeSystemDescriptionFactory.createTypeSystemDescription();
-		assertThat(tsd.getTypes()).hasSize(52);
+
+		var expectedTsd = UIMAFramework.getXMLParser()
+				.parseTypeSystemDescription(
+						new XMLInputSource(getClass().getResource("EvaluationTypeSystem.xml")));
+
+		var detectedTsd = TypeSystemDescriptionFactory.createTypeSystemDescription();
+
+		assertThat(detectedTsd.getTypes()) //
+				.extracting(TypeDescription::getName).containsAll(
+						Stream.of(expectedTsd.getTypes()).map(TypeDescription::getName).toList());
+
+		assertThat(detectedTsd.getTypes()).hasSize(52);
 	}
 }

--- a/measurement-typesystem/src/main/java/de/averbis/textanalysis/types/measurement/MeasurementTypeSystemDescriptionProvider.java
+++ b/measurement-typesystem/src/main/java/de/averbis/textanalysis/types/measurement/MeasurementTypeSystemDescriptionProvider.java
@@ -15,55 +15,18 @@
  */
 package de.averbis.textanalysis.types.measurement;
 
-import static org.apache.uima.util.TypeSystemUtil.loadTypeSystemDescriptionsFromClasspath;
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.uima.spi.TypeSystemProvider;
+import org.apache.uima.spi.TypeSystemProvider_ImplBase;
 
-import org.apache.uima.jcas.cas.TOP;
-import org.apache.uima.resource.metadata.TypeDescription;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.apache.uima.spi.JCasClassProvider;
-import org.apache.uima.spi.TypeSystemDescriptionProvider;
+import aQute.bnd.annotation.spi.ServiceProvider;
 
-public class MeasurementTypeSystemDescriptionProvider
-		implements TypeSystemDescriptionProvider, JCasClassProvider {
+@ServiceProvider(value = TypeSystemProvider.class, resolution = OPTIONAL)
+public class MeasurementTypeSystemDescriptionProvider extends TypeSystemProvider_ImplBase {
 
-	private List<TypeSystemDescription> typeSystemDescriptions;
-	private List<Class<? extends TOP>> jCasClasses;
+	public MeasurementTypeSystemDescriptionProvider() {
 
-
-	@Override
-	public synchronized List<TypeSystemDescription> listTypeSystemDescriptions() {
-
-		if (typeSystemDescriptions == null) {
-			typeSystemDescriptions = loadTypeSystemDescriptionsFromClasspath(getClass(), //
-					"MeasurementTypeSystem.xml");
-		}
-		return typeSystemDescriptions;
-	}
-
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public synchronized List<Class<? extends TOP>> listJCasClasses() {
-
-		if (jCasClasses == null) {
-			List<Class<? extends TOP>> classes = new ArrayList<>();
-			ClassLoader cl = getClass().getClassLoader();
-
-			for (TypeSystemDescription tsd : listTypeSystemDescriptions()) {
-				for (TypeDescription td : tsd.getTypes()) {
-					try {
-						classes.add((Class<? extends TOP>) cl.loadClass(td.getName()));
-					} catch (ClassNotFoundException e) {
-						// This is acceptable - there may not be a JCas class
-					}
-				}
-			}
-			jCasClasses = classes;
-		}
-
-		return jCasClasses;
+		setTypeSystemLocations("MeasurementTypeSystem.xml");
 	}
 }

--- a/measurement-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
+++ b/measurement-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
@@ -1,0 +1,1 @@
+de.averbis.textanalysis.types.measurement.MeasurementTypeSystemDescriptionProvider

--- a/named-entity-typesystem/src/main/java/de/averbis/textanalysis/types/NamedEntityTypeSystemDescriptionProvider.java
+++ b/named-entity-typesystem/src/main/java/de/averbis/textanalysis/types/NamedEntityTypeSystemDescriptionProvider.java
@@ -15,57 +15,21 @@
  */
 package de.averbis.textanalysis.types;
 
-import static org.apache.uima.util.TypeSystemUtil.loadTypeSystemDescriptionsFromClasspath;
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.uima.spi.TypeSystemProvider;
+import org.apache.uima.spi.TypeSystemProvider_ImplBase;
 
-import org.apache.uima.jcas.cas.TOP;
-import org.apache.uima.resource.metadata.TypeDescription;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.apache.uima.spi.JCasClassProvider;
-import org.apache.uima.spi.TypeSystemDescriptionProvider;
+import aQute.bnd.annotation.spi.ServiceProvider;
 
-public class NamedEntityTypeSystemDescriptionProvider
-		implements TypeSystemDescriptionProvider, JCasClassProvider {
+@ServiceProvider(value = TypeSystemProvider.class, resolution = OPTIONAL)
+public class NamedEntityTypeSystemDescriptionProvider extends TypeSystemProvider_ImplBase {
 
-	private List<TypeSystemDescription> typeSystemDescriptions;
-	private List<Class<? extends TOP>> jCasClasses;
+	public NamedEntityTypeSystemDescriptionProvider() {
 
-
-	@Override
-	public synchronized List<TypeSystemDescription> listTypeSystemDescriptions() {
-
-		if (typeSystemDescriptions == null) {
-			typeSystemDescriptions = loadTypeSystemDescriptionsFromClasspath(getClass(), //
-					"NamedEntityTypeSystem.xml", //
-					"GenericRelationTypeSystem.xml", //
-					"NeuralTypeSystem.xml");
-		}
-		return typeSystemDescriptions;
-	}
-
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public synchronized List<Class<? extends TOP>> listJCasClasses() {
-
-		if (jCasClasses == null) {
-			List<Class<? extends TOP>> classes = new ArrayList<>();
-			ClassLoader cl = getClass().getClassLoader();
-
-			for (TypeSystemDescription tsd : listTypeSystemDescriptions()) {
-				for (TypeDescription td : tsd.getTypes()) {
-					try {
-						classes.add((Class<? extends TOP>) cl.loadClass(td.getName()));
-					} catch (ClassNotFoundException e) {
-						// This is acceptable - there may not be a JCas class
-					}
-				}
-			}
-			jCasClasses = classes;
-		}
-
-		return jCasClasses;
+		setTypeSystemLocations( //
+				"NamedEntityTypeSystem.xml", //
+				"GenericRelationTypeSystem.xml", //
+				"NeuralTypeSystem.xml");
 	}
 }

--- a/named-entity-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
+++ b/named-entity-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
@@ -1,0 +1,1 @@
+de.averbis.textanalysis.types.NamedEntityTypeSystemDescriptionProvider

--- a/numeric-value-typesystem/src/main/java/de/averbis/textanalysis/types/numericvalue/NumericValueTypeSystemDescriptionProvider.java
+++ b/numeric-value-typesystem/src/main/java/de/averbis/textanalysis/types/numericvalue/NumericValueTypeSystemDescriptionProvider.java
@@ -15,55 +15,18 @@
  */
 package de.averbis.textanalysis.types.numericvalue;
 
-import static org.apache.uima.util.TypeSystemUtil.loadTypeSystemDescriptionsFromClasspath;
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.uima.spi.TypeSystemProvider;
+import org.apache.uima.spi.TypeSystemProvider_ImplBase;
 
-import org.apache.uima.jcas.cas.TOP;
-import org.apache.uima.resource.metadata.TypeDescription;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.apache.uima.spi.JCasClassProvider;
-import org.apache.uima.spi.TypeSystemDescriptionProvider;
+import aQute.bnd.annotation.spi.ServiceProvider;
 
-public class NumericValueTypeSystemDescriptionProvider
-		implements TypeSystemDescriptionProvider, JCasClassProvider {
+@ServiceProvider(value = TypeSystemProvider.class, resolution = OPTIONAL)
+public class NumericValueTypeSystemDescriptionProvider extends TypeSystemProvider_ImplBase {
 
-	private List<TypeSystemDescription> typeSystemDescriptions;
-	private List<Class<? extends TOP>> jCasClasses;
+	public NumericValueTypeSystemDescriptionProvider() {
 
-
-	@Override
-	public synchronized List<TypeSystemDescription> listTypeSystemDescriptions() {
-
-		if (typeSystemDescriptions == null) {
-			typeSystemDescriptions = loadTypeSystemDescriptionsFromClasspath(getClass(), //
-					"NumericValueTypeSystem.xml");
-		}
-		return typeSystemDescriptions;
-	}
-
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public synchronized List<Class<? extends TOP>> listJCasClasses() {
-
-		if (jCasClasses == null) {
-			List<Class<? extends TOP>> classes = new ArrayList<>();
-			ClassLoader cl = getClass().getClassLoader();
-
-			for (TypeSystemDescription tsd : listTypeSystemDescriptions()) {
-				for (TypeDescription td : tsd.getTypes()) {
-					try {
-						classes.add((Class<? extends TOP>) cl.loadClass(td.getName()));
-					} catch (ClassNotFoundException e) {
-						// This is acceptable - there may not be a JCas class
-					}
-				}
-			}
-			jCasClasses = classes;
-		}
-
-		return jCasClasses;
+		setTypeSystemLocations("NumericValueTypeSystem.xml");
 	}
 }

--- a/numeric-value-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
+++ b/numeric-value-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
@@ -1,0 +1,1 @@
+de.averbis.textanalysis.types.numericvalue.NumericValueTypeSystemDescriptionProvider

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.averbis.textanalysis</groupId>
 		<artifactId>parent-pom-typesystems</artifactId>
-		<version>4.1.0</version>
+		<version>4.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>core-typesystems</artifactId>
@@ -16,11 +16,11 @@
 	<url>https://github.com/averbis/core-typesystems</url>
 
 	<properties>
-		<uima-version>3.4.1</uima-version>
-		<uimafit-version>3.4.0</uimafit-version>
-		<junit-jupiter-version>5.9.3</junit-jupiter-version>
+		<bnd-annotation-version>7.0.0</bnd-annotation-version>
+		<uima-version>3.6.0-SNAPSHOT</uima-version>
+		<junit-jupiter-version>5.11.1</junit-jupiter-version>
 		<assertj-version>3.24.2</assertj-version>
-		<slf4j-version>1.7.36</slf4j-version>
+		<slf4j-version>2.0.16</slf4j-version>
 	</properties>
 
 	<licenses>
@@ -108,6 +108,11 @@
 	
 	<dependencies>
 		<dependency>
+			<groupId>biz.aQute.bnd</groupId>
+			<artifactId>biz.aQute.bnd.annotation</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
@@ -135,18 +140,29 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.uima</groupId>
-				<artifactId>uimafit-core</artifactId>
-				<version>${uimafit-version}</version>
+				<artifactId>uimaj-bom</artifactId>
+				<version>${uima-version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>
-				<artifactId>assertj-core</artifactId>
+				<artifactId>assertj-bom</artifactId>
 				<version>${assertj-version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-simple</artifactId>
+				<artifactId>slf4j-bom</artifactId>
 				<version>${slf4j-version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>biz.aQute.bnd.annotation</artifactId>
+				<version>${bnd-annotation-version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -156,7 +172,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.2</version>
 				<dependencies>
 					<dependency>
 						<groupId>org.junit.jupiter</groupId>

--- a/temporal-typesystem/src/main/java/de/averbis/textanalysis/types/temporal/TemporalTypeSystemDescriptionProvider.java
+++ b/temporal-typesystem/src/main/java/de/averbis/textanalysis/types/temporal/TemporalTypeSystemDescriptionProvider.java
@@ -15,55 +15,18 @@
  */
 package de.averbis.textanalysis.types.temporal;
 
-import static org.apache.uima.util.TypeSystemUtil.loadTypeSystemDescriptionsFromClasspath;
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.uima.spi.TypeSystemProvider;
+import org.apache.uima.spi.TypeSystemProvider_ImplBase;
 
-import org.apache.uima.jcas.cas.TOP;
-import org.apache.uima.resource.metadata.TypeDescription;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.apache.uima.spi.JCasClassProvider;
-import org.apache.uima.spi.TypeSystemDescriptionProvider;
+import aQute.bnd.annotation.spi.ServiceProvider;
 
-public class TemporalTypeSystemDescriptionProvider
-		implements TypeSystemDescriptionProvider, JCasClassProvider {
+@ServiceProvider(value = TypeSystemProvider.class, resolution = OPTIONAL)
+public class TemporalTypeSystemDescriptionProvider extends TypeSystemProvider_ImplBase {
 
-	private List<TypeSystemDescription> typeSystemDescriptions;
-	private List<Class<? extends TOP>> jCasClasses;
+	public TemporalTypeSystemDescriptionProvider() {
 
-
-	@Override
-	public synchronized List<TypeSystemDescription> listTypeSystemDescriptions() {
-
-		if (typeSystemDescriptions == null) {
-			typeSystemDescriptions = loadTypeSystemDescriptionsFromClasspath(getClass(), //
-					"TemporalTypeSystem.xml");
-		}
-		return typeSystemDescriptions;
-	}
-
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public synchronized List<Class<? extends TOP>> listJCasClasses() {
-
-		if (jCasClasses == null) {
-			List<Class<? extends TOP>> classes = new ArrayList<>();
-			ClassLoader cl = getClass().getClassLoader();
-
-			for (TypeSystemDescription tsd : listTypeSystemDescriptions()) {
-				for (TypeDescription td : tsd.getTypes()) {
-					try {
-						classes.add((Class<? extends TOP>) cl.loadClass(td.getName()));
-					} catch (ClassNotFoundException e) {
-						// This is acceptable - there may not be a JCas class
-					}
-				}
-			}
-			jCasClasses = classes;
-		}
-
-		return jCasClasses;
+		setTypeSystemLocations("TemporalTypeSystem.xml");
 	}
 }

--- a/temporal-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
+++ b/temporal-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
@@ -1,0 +1,1 @@
+de.averbis.textanalysis.types.temporal.TemporalTypeSystemDescriptionProvider

--- a/text-typesystem/src/main/java/de/averbis/textanalysis/types/text/TextTypeSystemDescriptionProvider.java
+++ b/text-typesystem/src/main/java/de/averbis/textanalysis/types/text/TextTypeSystemDescriptionProvider.java
@@ -15,55 +15,20 @@
  */
 package de.averbis.textanalysis.types.text;
 
-import static org.apache.uima.util.TypeSystemUtil.loadTypeSystemDescriptionsFromClasspath;
+import static aQute.bnd.annotation.Resolution.OPTIONAL;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.uima.spi.TypeSystemProvider;
+import org.apache.uima.spi.TypeSystemProvider_ImplBase;
 
-import org.apache.uima.jcas.cas.TOP;
-import org.apache.uima.resource.metadata.TypeDescription;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.apache.uima.spi.JCasClassProvider;
-import org.apache.uima.spi.TypeSystemDescriptionProvider;
+import aQute.bnd.annotation.spi.ServiceProvider;
 
-public class TextTypeSystemDescriptionProvider
-		implements TypeSystemDescriptionProvider, JCasClassProvider {
+@ServiceProvider(value = TypeSystemProvider.class, resolution = OPTIONAL)
+public class TextTypeSystemDescriptionProvider extends TypeSystemProvider_ImplBase {
 
-	private List<TypeSystemDescription> typeSystemDescriptions;
-	private List<Class<? extends TOP>> jCasClasses;
+	public TextTypeSystemDescriptionProvider() {
 
-
-	@Override
-	public synchronized List<TypeSystemDescription> listTypeSystemDescriptions() {
-
-		if (typeSystemDescriptions == null) {
-			typeSystemDescriptions = loadTypeSystemDescriptionsFromClasspath(getClass(), //
-					"TextTypeSystem.xml");
-		}
-		return typeSystemDescriptions;
-	}
-
-
-	@SuppressWarnings("unchecked")
-	@Override
-	public synchronized List<Class<? extends TOP>> listJCasClasses() {
-
-		if (jCasClasses == null) {
-			List<Class<? extends TOP>> classes = new ArrayList<>();
-			ClassLoader cl = getClass().getClassLoader();
-
-			for (TypeSystemDescription tsd : listTypeSystemDescriptions()) {
-				for (TypeDescription td : tsd.getTypes()) {
-					try {
-						classes.add((Class<? extends TOP>) cl.loadClass(td.getName()));
-					} catch (ClassNotFoundException e) {
-						// This is acceptable - there may not be a JCas class
-					}
-				}
-			}
-			jCasClasses = classes;
-		}
-
-		return jCasClasses;
+		setTypeSystemLocations(//
+				"TextTypeSystem.xml", //
+				"TextUtilTypeSystem.xml");
 	}
 }

--- a/text-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
+++ b/text-typesystem/src/main/resources/META-INF/services/org.apache.uima.spi.TypeSystemProvider
@@ -1,0 +1,1 @@
+de.averbis.textanalysis.types.text.TextTypeSystemDescriptionProvider


### PR DESCRIPTION
**What's in the PR**
- Averbis Type Parent POM 4.1.0 -> 4.2.0-SNAPSHOT
- UIMAJ 3.4.1 -> 3.6.0-SNAPSHOT
- slf4j 1.7.36 -> 2.0.16
- junit 5.9.3 -> 5.11.1
- Generate OSGI capabilities for SPIs using BND service annotations
- Switch dependency imports to BOMs as much as possible
- Upgrade type system providers to the new UIMA 3.6.x TypeSystemProvider interface

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
